### PR TITLE
Grouping not found URLs ticket 1425622

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -289,7 +289,7 @@ describe('Plugin', function () {
             ['/hello', '/hello'],
             ['/hello/world', '/hello/[name]'],
             ['/hello/other', '/hello/other'],
-            ['/error/not_found', '/error/not_found', satisfies(pkg.version, '>=10') ? 404 : 500],
+            ['/error/not_found', '/404', satisfies(pkg.version, '>=10') ? 404 : 500],
             ['/error/get_server_side_props', '/error/get_server_side_props', 500]
           ]
           pathTests.forEach(([url, expectedPath, statusCode]) => {


### PR DESCRIPTION
Nextjs service resources are flooded with thousands of unique resources that are created each time an HTTP request is asking for a non-existent page or static file.

This PR shows what I would expect the test to look like.